### PR TITLE
fix: add missing header fcntl.h

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <sys/epoll.h>
+#include <fcntl.h>
 #include <errno.h>
 
 #include <cstring>


### PR DESCRIPTION
The code uses fcntl() to set the socket to non-blocking mode, and fails to compile without the header.